### PR TITLE
Merge Dev into Main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     tags: ["v*"]
   pull_request:
 
@@ -80,7 +80,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -88,7 +88,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != ''
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != '' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -99,7 +99,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           build-args: |
             SEEKARR_VERSION=${{ steps.meta_ghcr.outputs.version }}
           tags: ${{ steps.meta_ghcr.outputs.tags }}
@@ -113,7 +113,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           build-args: |
             SEEKARR_VERSION=${{ steps.meta_dockerhub.outputs.version }}
           tags: ${{ steps.meta_dockerhub.outputs.tags }}

--- a/seekarr/engine.py
+++ b/seekarr/engine.py
@@ -441,14 +441,10 @@ class Engine:
                     before_missing = len(missing_items)
                     before_cutoff = len(cutoff_items)
                     missing_items = [
-                        ep
-                        for ep in missing_items
-                        if int(getattr(ep, "episode_id", 0) or 0) not in queued_episode_ids
+                        ep for ep in missing_items if int(getattr(ep, "episode_id", 0) or 0) not in queued_episode_ids
                     ]
                     cutoff_items = [
-                        ep
-                        for ep in cutoff_items
-                        if int(getattr(ep, "episode_id", 0) or 0) not in queued_episode_ids
+                        ep for ep in cutoff_items if int(getattr(ep, "episode_id", 0) or 0) not in queued_episode_ids
                     ]
                     skipped_missing = before_missing - len(missing_items)
                     skipped_cutoff = before_cutoff - len(cutoff_items)

--- a/seekarr/state.py
+++ b/seekarr/state.py
@@ -518,6 +518,18 @@ class StateStore:
             ).fetchone()
         return int(row["c"] or 0) if row else 0
 
+    def count_search_actions_for_item(self, hunt_type: str, instance_id: int, item_key: str) -> int:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                FROM search_action
+                WHERE hunt_type = ? AND instance_id = ? AND item_key = ?
+                """,
+                (str(hunt_type), int(instance_id), str(item_key)),
+            ).fetchone()
+        return int(row["c"] or 0) if row else 0
+
     def set_scheduler_heartbeat(self) -> None:
         now = _utc_now()
         with self._connect() as conn:

--- a/tests/test_arr.py
+++ b/tests/test_arr.py
@@ -1,0 +1,57 @@
+import logging
+
+from seekarr.arr import ArrClient
+from seekarr.config import ArrConfig
+
+
+def test_fetch_series_season_inventory_tracks_unaired(monkeypatch) -> None:
+    client = ArrClient(
+        name="sonarr",
+        config=ArrConfig(enabled=True, url="http://example", api_key="abc"),
+        timeout_seconds=5,
+        verify_ssl=True,
+        logger=logging.getLogger("test"),
+    )
+
+    payload = [
+        {"seasonNumber": 1, "airDateUtc": "2025-01-01T00:00:00Z", "hasFile": False},
+        {"seasonNumber": 1, "airDateUtc": "2025-01-02T00:00:00Z", "hasFile": True},
+        {"seasonNumber": 1, "airDateUtc": "2099-01-01T00:00:00Z", "hasFile": False},
+    ]
+
+    def _fake_request(method, path, params=None, json_data=None):  # noqa: ANN001
+        assert method == "GET"
+        assert path == "/api/v3/episode"
+        return payload
+
+    monkeypatch.setattr(client, "_request", _fake_request)
+
+    inv = client.fetch_series_season_inventory(123)
+    assert inv[1]["aired_total"] == 2
+    assert inv[1]["aired_downloaded"] == 1
+    assert inv[1]["unaired_total"] == 1
+
+
+def test_fetch_queue_episode_ids(monkeypatch) -> None:
+    client = ArrClient(
+        name="sonarr",
+        config=ArrConfig(enabled=True, url="http://example", api_key="abc"),
+        timeout_seconds=5,
+        verify_ssl=True,
+        logger=logging.getLogger("test"),
+    )
+
+    rows = [
+        {"episodeId": 10},
+        {"episode": {"id": 11}},
+        {"episodeId": 0},
+        {},
+    ]
+
+    def _fake_fetch(path):  # noqa: ANN001
+        assert path == "/api/v3/queue"
+        return rows
+
+    monkeypatch.setattr(client, "_fetch_paged_records", _fake_fetch)
+
+    assert client.fetch_queue_episode_ids() == {10, 11}

--- a/tests/test_engine_order.py
+++ b/tests/test_engine_order.py
@@ -1,0 +1,12 @@
+from seekarr.arr import WantedEpisode
+from seekarr.engine import _episode_order_key
+
+
+def test_episode_order_key_sorts_season_episode_ascending() -> None:
+    episodes = [
+        WantedEpisode(episode_id=3, series_id=1, series_title="x", series_tvdb_id=1, season_number=1, episode_number=3),
+        WantedEpisode(episode_id=1, series_id=1, series_title="x", series_tvdb_id=1, season_number=1, episode_number=1),
+        WantedEpisode(episode_id=2, series_id=1, series_title="x", series_tvdb_id=1, season_number=1, episode_number=2),
+    ]
+    ordered = sorted(episodes, key=_episode_order_key)
+    assert [e.episode_number for e in ordered] == [1, 2, 3]

--- a/tests/test_engine_smart_order.py
+++ b/tests/test_engine_smart_order.py
@@ -1,0 +1,13 @@
+from seekarr.engine import _prioritize_cold_start_seasons
+
+
+def test_prioritize_cold_start_seasons_orders_within_series() -> None:
+    grouped = [
+        ((101, 3), []),
+        ((202, 1), []),
+        ((101, 1), []),
+        ((101, 2), []),
+        ((202, 2), []),
+    ]
+    out = _prioritize_cold_start_seasons(grouped, {101})
+    assert [x[0] for x in out] == [(101, 1), (202, 1), (101, 2), (101, 3), (202, 2)]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,12 @@
+from seekarr.state import StateStore
+
+
+def test_count_search_actions_for_item(tmp_path) -> None:
+    store = StateStore(str(tmp_path / "seekarr.db"))
+    assert store.count_search_actions_for_item("sonarr", 1, "season:10:1") == 0
+
+    store.record_search_action("sonarr", 1, "Sonarr", "season:10:1", "Show Season 01 (Pack)")
+    store.record_search_action("sonarr", 1, "Sonarr", "season:10:1", "Show Season 01 (Pack)")
+    store.record_search_action("sonarr", 1, "Sonarr", "episode:55", "Show S01E01")
+
+    assert store.count_search_actions_for_item("sonarr", 1, "season:10:1") == 2


### PR DESCRIPTION
## Summary
This PR improves Sonarr smart-search behavior and hardens CI workflow behavior for `dev`.

### Sonarr smart-search improvements
- Added Sonarr queue awareness: Seekarr now reads `/api/v3/queue` per run and skips wanted episodes already queued.
- Added deterministic episode ordering for per-episode paths (`SxxEyy` ascending).
- Fixed smart mode for empty-but-ongoing seasons: falls back to episode search instead of pack-first.
- Added cold-start full-series ordering: when multiple monitored seasons are empty, prioritize earliest seasons first.
- Added fallback logic for missing season packs: after repeated season-pack attempts on an empty season, switch to per-episode searches.
- Added state helper to count prior per-item search actions to support attempt-based fallback.

### CI/workflow improvements
- CI now runs on pushes to both `main` and `dev`.
- Docker workflow runs on pushes to both `main` and `dev` (and tags), but publishing is restricted to:
  - `main`
  - `v*` tags
- `dev` still gets Docker build/test coverage without pushing images.

## Validation
Ran locally before push:
- `python -m ruff check .`
- `python -m ruff format --check .`
- `PYTHONPATH=. pytest -q` (all tests passing)
